### PR TITLE
OmniJaws: fill incomplete forecast list with dummies

### DIFF
--- a/src/org/omnirom/omnijaws/OpenWeatherMapProvider.java
+++ b/src/org/omnirom/omnijaws/OpenWeatherMapProvider.java
@@ -182,6 +182,20 @@ public class OpenWeatherMapProvider extends AbstractWeatherProvider {
             }
             result.add(item);
         }
+        // clients assume there are 5  entries - so fill with dummy if needed
+        if (result.size() < 5) {
+            for (int i = result.size(); i < 5; i++) {
+                Log.w(TAG, "Missing forecast for day " + i + " creating dummy");
+                DayForecast item = new DayForecast(
+                        /* low */ 0,
+                        /* high */ 0,
+                        /* condition */ "",
+                        /* conditionCode */ -1,
+                        "NaN",
+                        metric);
+                result.add(item);
+            }
+        }
         return result;
     }
 


### PR DESCRIPTION
some clients assume there are always 5 forecast entries available
and will derp hard if not. So add a check and add dummy ones if needed

Change-Id: I001a6879440d57862feedddf0e99236054370649
Signed-off-by: mydongistiny <jaysonedson@gmail.com>